### PR TITLE
chore: hide about page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,14 +43,14 @@ pre = ""
 title = ""
 url = "/categories/"
 weight = 3
-[[menu.main]]
-identifier = "about"
-name = "About"
-post = ""
-pre = ""
-title = ""
-url = "/about/"
-weight = 4
+# [[menu.main]]
+# identifier = "about"
+# name = "About"
+# post = ""
+# pre = ""
+# title = ""
+# url = "/about/"
+# weight = 4
 [[menu.links]]
 identifier = "github"
 name = "GitHub"


### PR DESCRIPTION
## Summary
buildに失敗するので、About pageを非表示にしました